### PR TITLE
Remove numerical/physical option

### DIFF
--- a/2d-double-mach-reflection/double-mach-reflection.ini
+++ b/2d-double-mach-reflection/double-mach-reflection.ini
@@ -22,7 +22,6 @@ shock-capturing = entropy-filter
 d-min = 1e-6
 p-min = 1e-6
 e-tol = 1e-6
-e-func = physical
 niters = 2
 
 [solver-time-integrator]

--- a/2d-viscous-shock-tube/viscous-shock-tube.ini
+++ b/2d-viscous-shock-tube/viscous-shock-tube.ini
@@ -23,7 +23,6 @@ shock-capturing = entropy-filter
 d-min = 1e-6
 p-min = 1e-6
 e-tol = 1e-6
-e-func = physical
 niters = 2
 
 [solver-time-integrator]


### PR DESCRIPTION
The current `numerical` option in entropy filter (defined as rho*s) is incorrect, and the correct implementation showed no benefit over the `physical` entropy functional.

This PR removes the `e_func` option from the test cases.